### PR TITLE
[API]: Add player api

### DIFF
--- a/data/api/functions/players/create/current.mcfunction
+++ b/data/api/functions/players/create/current.mcfunction
@@ -1,0 +1,3 @@
+execute unless entity @s[type=player] run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Error","color":"dark_red"},{"text":"] "},{"text":"Unable to create new player as ","color":"red"},{"selector":"@s","color":"red"},{"text":"!","color":"red"}]
+execute if score @s[type=player] ID matches 1.. run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Warning","color":"gold"},{"text":"] "},{"text":"Not able to recreate a player that already has an id (","color":"yellow"},{"score":{"name":"@s","objective":"ID"},"color":"yellow"},{"text":") defined!","color":"yellow"}]
+execute if entity @s[type=player] unless score @s ID matches 1.. run function api:players/create/main

--- a/data/api/functions/players/create/current.mcfunction
+++ b/data/api/functions/players/create/current.mcfunction
@@ -1,3 +1,5 @@
 execute unless entity @s[type=player] run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Error","color":"dark_red"},{"text":"] "},{"text":"Unable to create new player as ","color":"red"},{"selector":"@s","color":"red"},{"text":"!","color":"red"}]
 execute if score @s[type=player] ID matches 1.. run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Warning","color":"gold"},{"text":"] "},{"text":"Not able to recreate a player that already has an id (","color":"yellow"},{"score":{"name":"@s","objective":"ID"},"color":"yellow"},{"text":") defined!","color":"yellow"}]
 execute if entity @s[type=player] unless score @s ID matches 1.. run function api:players/create/main
+
+tag @s add registered

--- a/data/api/functions/players/create/default_schema.mcfunction
+++ b/data/api/functions/players/create/default_schema.mcfunction
@@ -1,0 +1,9 @@
+data modify storage api:players default set value {id: 0, uuid: [], name: "", lastOnline: 0, rankId: 0}
+data modify storage api:players default.display set value {white: "", rank: ""}
+data modify storage api:players default.friend set value {list: [], requests: [], invites: []}
+data modify storage api:players default.party set value {id: 0, requests: [], invites: [], members: [], temp_members: []}
+
+# statistics
+data modify storage commandmc:players default.statistics set value {}
+data modify storage commandmc:players default.statistics.lobby set value {play: 0}
+# more statistics can be added when needed

--- a/data/api/functions/players/create/default_schema.mcfunction
+++ b/data/api/functions/players/create/default_schema.mcfunction
@@ -4,6 +4,6 @@ data modify storage api:players default.friend set value {list: [], requests: []
 data modify storage api:players default.party set value {id: 0, requests: [], invites: [], members: [], temp_members: []}
 
 # statistics
-data modify storage commandmc:players default.statistics set value {}
-data modify storage commandmc:players default.statistics.lobby set value {play: 0}
+data modify storage api:players default.statistics set value {}
+data modify storage api:players default.statistics.lobby set value {play: 0}
 # more statistics can be added when needed

--- a/data/api/functions/players/create/main.mcfunction
+++ b/data/api/functions/players/create/main.mcfunction
@@ -1,0 +1,11 @@
+execute unless data storage api:players default run function api:players/create/default_schema
+execute unless data storage api:players list run data modify storage api:players list set value []
+
+data modify storage api:players list append from storage api:players default
+data modify storage api:players list[-1].uuid set from entity @s UUID
+
+scoreboard players add #Maxid ID 1
+scoreboard players operation @s ID = #Maxid ID
+execute store result storage api:players list[-1].id int 1 run scoreboard players get @s ID
+
+execute positioned 0 0 0 run function api:players/update/ranks/current

--- a/data/api/functions/players/get/current.mcfunction
+++ b/data/api/functions/players/get/current.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players operation #id temp = @s ID
+data modify storage api:common get set from storage api:players list
+function api:common/get
+execute if data storage api:common result run data modify storage api:players current set from storage api:common result

--- a/data/api/functions/players/get/nearest.mcfunction
+++ b/data/api/functions/players/get/nearest.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players operation #id temp = @p ID
+data modify storage api:common get set from storage api:players list
+function api:common/get
+execute if data storage api:common result run data modify storage api:players nearest set from storage api:common result

--- a/data/api/functions/players/get/specific.mcfunction
+++ b/data/api/functions/players/get/specific.mcfunction
@@ -1,0 +1,3 @@
+data modify storage api:common get set from storage api:players list
+function api:common/get
+execute if data storage api:common result run data modify storage api:players specific set from storage api:common result

--- a/data/api/functions/players/save/current.mcfunction
+++ b/data/api/functions/players/save/current.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players operation #id temp = @s ID
+data modify storage api:common save set from storage api:players list
+data modify storage api:common payload set from storage api:players current
+function api:common/save
+data modify storage api:players list set from storage api:common save

--- a/data/api/functions/players/save/nearest.mcfunction
+++ b/data/api/functions/players/save/nearest.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players operation #id temp = @p ID
+data modify storage api:common save set from storage api:players list
+data modify storage api:common payload set from storage api:players nearest
+function api:common/save
+data modify storage api:players list set from storage api:common save

--- a/data/api/functions/players/save/specific.mcfunction
+++ b/data/api/functions/players/save/specific.mcfunction
@@ -1,0 +1,4 @@
+data modify storage api:common save set from storage api:players list
+data modify storage api:common payload set from storage api:players specific
+function api:common/save
+data modify storage api:players list set from storage api:common save

--- a/data/api/functions/players/update/ranks/current.mcfunction
+++ b/data/api/functions/players/update/ranks/current.mcfunction
@@ -1,6 +1,7 @@
 function api:players/get/current
 
 loot spawn ~ ~ ~ loot vm:current_players_head
+data modify storage api:players current.name set from entity @e[type=item,distance=..2,sort=nearest,limit=1] Item.tag.SkullOwner.Name
 
 data modify storage api:ranks playerName.selected set from storage api:players current.name
 

--- a/data/api/functions/players/update/ranks/current.mcfunction
+++ b/data/api/functions/players/update/ranks/current.mcfunction
@@ -1,0 +1,23 @@
+function api:players/get/current
+
+loot spawn ~ ~ ~ loot vm:current_players_head
+
+data modify storage api:ranks playerName.selected set from storage api:players current.name
+
+# The values of those storage items are defined in the functions/ranks/init.mcfunction file - A template with the playerName.selected is used to specify the player name.
+execute if score @s rank = #player_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.player
+execute if score @s rank = #premium_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.premium
+execute if score @s rank = #rainbow_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.rainbow
+execute if score @s rank = #content_creator_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.content_creator
+execute if score @s rank = #builder_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.builder
+execute if score @s rank = #helper_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.helper
+execute if score @s rank = #developer_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.developer
+execute if score @s rank = #moderator_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.moderator
+execute if score @s rank = #admin_rank value run data modify block ~ ~ ~ Text1 set from storage api:ranks playerName.admin
+
+data modify storage api:players current.display.rank set from block ~ ~ ~ Text1
+data modify block ~ ~ ~ Text1 set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"white"}'
+data modify storage api:players current.display.white set from block ~ ~ ~ Text1
+kill @e[type=item,distance=..2,sort=nearest,limit=1]
+
+function api:players/save/current

--- a/data/api/functions/ranks/load.mcfunction
+++ b/data/api/functions/ranks/load.mcfunction
@@ -1,0 +1,22 @@
+scoreboard objectives add rank dummy
+
+data modify storage api:ranks playerName set value {selected: ""}
+data modify storage api:ranks playerName.player set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"gray"}'
+data modify storage api:ranks playerName.premium set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"gold"}'
+data modify storage api:ranks playerName.rainbow set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"green"}'
+data modify storage api:ranks playerName.content_creator set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"light_purple"}'
+data modify storage api:ranks playerName.builder set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"dark_aqua"}'
+data modify storage api:ranks playerName.helper set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"blue"}'
+data modify storage api:ranks playerName.developer set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"aqua"}'
+data modify storage api:ranks playerName.moderator set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"blue"}'
+data modify storage api:ranks playerName.admin set value '{"storage":"api:ranks","nbt":"playerName.selected","color":"red"}'
+
+scoreboard players set #player_rank value 0
+scoreboard players set #premium_rank value 1
+scoreboard players set #rainbow_rank value 2
+scoreboard players set #content_creator_rank value 3
+scoreboard players set #builder_rank value 4
+scoreboard players set #helper_rank value 5
+scoreboard players set #developer_rank value 6
+scoreboard players set #moderator_rank value 7
+scoreboard players set #admin_rank value 8

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -1,7 +1,3 @@
-scoreboard players add @a ID 0
-execute as @a[scores={ID=..0}] run scoreboard players add #Maxid ID 1
-execute as @a[scores={ID=..0}] run scoreboard players operation @s ID = #Maxid ID
-
 execute as @a[team=] run tellraw @s [{"selector":"@s","color":"aqua"},{"text":" joined for the first time!","color":"green"}]
 scoreboard players set @a[team=] rank 90
 scoreboard players set @a[team=] l 1
@@ -11,7 +7,7 @@ scoreboard players set @a[scores={rejoin=1..}] l 1
 execute as @a[scores={rejoin=1..}] run tellraw @s [{"text":"Welcome back, ","color":"green"},{"selector":"@s","color":"aqua"},{"text":"!"}]
 scoreboard players reset @a[scores={rejoin=1..}] rejoin
 
-execute at @a[tag=lobby,nbt={SelectedItem:{id:"minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
+execute at @a[tag=lobby,nbt={SelectedItem: {id: "minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
 execute as @e[type=chest_minecart,tag=gui] at @s unless entity @a[distance=..3] run tp @s ~ -100 ~
 execute as @e[type=chest_minecart,tag=gui] at @s unless entity @a[distance=..3] run kill @s
 

--- a/data/vm/functions/tick.mcfunction
+++ b/data/vm/functions/tick.mcfunction
@@ -1,22 +1,24 @@
-execute as @a[tag=fall,nbt={OnGround:0b}] store result score @s apply_damage run data get entity @s FallDistance
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run scoreboard players remove @s apply_damage 3
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run function vm:damage
+execute as @a[tag=!registered] run function api:players/create/current
 
-spawnpoint @a[tag=lobby,nbt={Dimension:"minecraft:overworld"}] 0 19 0
+execute as @a[tag=fall,nbt={OnGround: 0b}] store result score @s apply_damage run data get entity @s FallDistance
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run scoreboard players remove @s apply_damage 3
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run function vm:damage
+
+spawnpoint @a[tag=lobby,nbt={Dimension: "minecraft:overworld"}] 0 19 0
 scoreboard players add @a playtime 1
 
 execute as @a[scores={l=1..}] run function vm:leave
 tp @a[scores={l=1..}] 0 19 0
 execute as @a[scores={l=1..}] run gamemode adventure @s
-item replace entity @a[scores={l=1..}] hotbar.4 with compass{display:{Name:'{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
+item replace entity @a[scores={l=1..}] hotbar.4 with compass{display: {Name: '{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
 scoreboard players reset @a[scores={l=1..}] l
 scoreboard players enable @a l
 
-item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage:430}
+item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage: 430}
 scoreboard players reset @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] doublejump
-effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] levitation 1 11 true
-execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
-execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] run item replace entity @s armor.chest with air
+effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] levitation 1 11 true
+execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
+execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] run item replace entity @s armor.chest with air
 
 execute as @e[type=chest_minecart,tag=lobby_gui] store result score @s itemCount run data get entity @s Items
 execute as @e[type=chest_minecart,tag=lobby_gui] unless score @s itemCount = @s itemOrgCount run function vm:gui/click

--- a/data/vm/loot_tables/current_players_head.json
+++ b/data/vm/loot_tables/current_players_head.json
@@ -7,8 +7,6 @@
           {
             "type": "item",
             "name": "minecraft:player_head",
-            "weight": 1000,
-            "quality": -1000,
             "functions": [
               {
                 "function": "minecraft:fill_player_head",

--- a/data/vm/loot_tables/current_players_head.json
+++ b/data/vm/loot_tables/current_players_head.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "item",
+            "name": "minecraft:player_head",
+            "weight": 1000,
+            "quality": -1000,
+            "functions": [
+              {
+                "function": "minecraft:fill_player_head",
+                "entity": "this"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
This pull request contains new functions for getting and saving data from the players data. Additionally it allows to create new players with the api functions. The player id definition has been moved to the player creation api to allow a single request to manage the whole player creation. Finally the ranks api storage has been added. It is used to manage the color of the players rank name.