### PR TITLE
Add UUID api and improve join logic

### DIFF
--- a/data/api/functions/players/create/main.mcfunction
+++ b/data/api/functions/players/create/main.mcfunction
@@ -9,3 +9,5 @@ scoreboard players operation @s ID = #Maxid ID
 execute store result storage api:players list[-1].id int 1 run scoreboard players get @s ID
 
 execute positioned 0 0 0 run function api:players/update/ranks/current
+
+function api:uuid/add

--- a/data/api/functions/uuid/add.mcfunction
+++ b/data/api/functions/uuid/add.mcfunction
@@ -1,0 +1,3 @@
+execute unless entity @s[type=player] run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Error","color":"dark_red"},{"text":"] "},{"text":"Not able to execute this function (add uuid) as ","color":"red"},{"selector":"@s","color":"red"},{"text":"!","color":"red"}]
+execute unless score @s[type=player] ID matches 1..4096 run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Error","color":"dark_red"},{"text":"] "},{"text":"Unable to add player to uuid list with invalid id!","color":"red"}]
+execute if entity @s[type=player] if score @s ID matches 1..4096 run function api:uuid/add/index

--- a/data/api/functions/uuid/add/index.mcfunction
+++ b/data/api/functions/uuid/add/index.mcfunction
@@ -1,0 +1,3 @@
+data modify storage api:uuid list append value {id: 0, uuid: []}
+execute store result storage api:uuid list[-1].id int 1 run scoreboard players get @s ID
+data modify storage api:uuid list[-1].uuid set from entity @s UUID

--- a/data/api/functions/uuid/check.mcfunction
+++ b/data/api/functions/uuid/check.mcfunction
@@ -1,0 +1,2 @@
+execute unless entity @s[type=player] run tellraw @a[tag=debug] ["",{"text":"["},{"text":"Error","color":"dark_red"},{"text":"] "},{"text":"Not able to execute this function (check uuid) as ","color":"red"},{"selector":"@s","color":"red"},{"text":"!","color":"red"}]
+execute if entity @s[type=player] run function api:uuid/check/index

--- a/data/api/functions/uuid/check/compare_uuids.mcfunction
+++ b/data/api/functions/uuid/check/compare_uuids.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set #matches temp 0
+execute if score #current_uuid_0 temp = #storage_uuid_0 temp if score #current_uuid_1 temp = #storage_uuid_1 temp if score #current_uuid_2 temp = #storage_uuid_2 temp if score #current_uuid_3 temp = #storage_uuid_3 temp run scoreboard players set #matches temp 1

--- a/data/api/functions/uuid/check/index.mcfunction
+++ b/data/api/functions/uuid/check/index.mcfunction
@@ -1,0 +1,15 @@
+#
+# Description: 	This function is used to check the uuid of the player for 
+#				joining the first time, again, with an other name, or with an other name that 
+#				has already been used by an other player
+# Author: 		Meier Lukas
+# Last Changes: 2022-01-04
+###
+
+execute store result score #current_uuid_0 temp run data get entity @s UUID[0]
+execute store result score #current_uuid_1 temp run data get entity @s UUID[1]
+execute store result score #current_uuid_2 temp run data get entity @s UUID[2]
+execute store result score #current_uuid_3 temp run data get entity @s UUID[3]
+
+execute if score @s id matches 1.. run function api:uuid/check/with_id
+execute unless score @s id matches 1.. run function api:uuid/check/without_id

--- a/data/api/functions/uuid/check/index.mcfunction
+++ b/data/api/functions/uuid/check/index.mcfunction
@@ -1,11 +1,3 @@
-#
-# Description: 	This function is used to check the uuid of the player for 
-#				joining the first time, again, with an other name, or with an other name that 
-#				has already been used by an other player
-# Author: 		Meier Lukas
-# Last Changes: 2022-01-04
-###
-
 execute store result score #current_uuid_0 temp run data get entity @s UUID[0]
 execute store result score #current_uuid_1 temp run data get entity @s UUID[1]
 execute store result score #current_uuid_2 temp run data get entity @s UUID[2]

--- a/data/api/functions/uuid/check/with_id.mcfunction
+++ b/data/api/functions/uuid/check/with_id.mcfunction
@@ -1,0 +1,9 @@
+function api:players/get/current
+execute store result score #storage_uuid_0 temp run data get storage api:players current.uuid[0]
+execute store result score #storage_uuid_1 temp run data get storage api:players current.uuid[1]
+execute store result score #storage_uuid_2 temp run data get storage api:players current.uuid[2]
+execute store result score #storage_uuid_3 temp run data get storage api:players current.uuid[3]
+
+function api:uuid/check/compare_uuids
+
+execute if score #matches temp matches 0 run function api:uuid/check/with_id/uuid_not_matches

--- a/data/api/functions/uuid/check/with_id.mcfunction
+++ b/data/api/functions/uuid/check/with_id.mcfunction
@@ -7,3 +7,4 @@ execute store result score #storage_uuid_3 temp run data get storage api:players
 function api:uuid/check/compare_uuids
 
 execute if score #matches temp matches 0 run function api:uuid/check/with_id/uuid_not_matches
+execute if score #matches temp matches 1 run function vm:join_server/main

--- a/data/api/functions/uuid/check/with_id/uuid_not_matches.mcfunction
+++ b/data/api/functions/uuid/check/with_id/uuid_not_matches.mcfunction
@@ -1,0 +1,1 @@
+function api:uuid/check/without_id

--- a/data/api/functions/uuid/check/without_id.mcfunction
+++ b/data/api/functions/uuid/check/without_id.mcfunction
@@ -3,6 +3,5 @@ execute store result score #lenght temp run data get storage api:uuid list
 data modify storage api:uuid temp set from storage api:uuid list
 execute unless score #lenght temp matches 0 run function api:uuid/check/without_id/repeat
 
-# TODO: handle firstjoin or othername join
-execute if score #foundId temp matches 0 run function lobby:join/first
-execute if score #foundId temp matches 2.. run function lobby:join/other_name
+execute if score #foundId temp matches 0 run function vm:join_server/first
+execute if score #foundId temp matches 2.. run function vm:join_server/other_name

--- a/data/api/functions/uuid/check/without_id.mcfunction
+++ b/data/api/functions/uuid/check/without_id.mcfunction
@@ -1,7 +1,7 @@
 scoreboard players set #foundId temp 0
-execute store result score #lenght temp run data get storage api:uuid list
+execute store result score #length temp run data get storage api:uuid list
 data modify storage api:uuid temp set from storage api:uuid list
-execute unless score #lenght temp matches 0 run function api:uuid/check/without_id/repeat
+execute unless score #length temp matches 0 run function api:uuid/check/without_id/repeat
 
 execute if score #foundId temp matches 0 run function vm:join_server/first
 execute if score #foundId temp matches 2.. run function vm:join_server/other_name

--- a/data/api/functions/uuid/check/without_id.mcfunction
+++ b/data/api/functions/uuid/check/without_id.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #foundId temp 0
+execute store result score #lenght temp run data get storage api:uuid list
+data modify storage api:uuid temp set from storage api:uuid list
+execute unless score #lenght temp matches 0 run function api:uuid/check/without_id/repeat
+
+# TODO: handle firstjoin or othername join
+execute if score #foundId temp matches 0 run function lobby:join/first
+execute if score #foundId temp matches 2.. run function lobby:join/other_name

--- a/data/api/functions/uuid/check/without_id/repeat.mcfunction
+++ b/data/api/functions/uuid/check/without_id/repeat.mcfunction
@@ -9,8 +9,8 @@ function api:uuid/check/compare_uuids
 
 execute if score #matches temp matches 1 store result score #foundId temp run data get storage api:uuid temp[0].id
 
-scoreboard players remove #lenght temp 1
+scoreboard players remove #length temp 1
 
 data remove storage api:uuid temp[0]
 
-execute unless score #lenght temp matches ..0 if score #matches temp matches 0 run function api:uuid/check/without_id/repeat
+execute unless score #length temp matches ..0 if score #matches temp matches 0 run function api:uuid/check/without_id/repeat

--- a/data/api/functions/uuid/check/without_id/repeat.mcfunction
+++ b/data/api/functions/uuid/check/without_id/repeat.mcfunction
@@ -1,0 +1,16 @@
+data modify storage api:uuid temp2 set from storage api:uuid temp[0].UUID
+
+execute store result score #storage_uuid_0 temp run data get storage api:uuid temp[0].uuid[0]
+execute store result score #storage_uuid_1 temp run data get storage api:uuid temp[0].uuid[1]
+execute store result score #storage_uuid_2 temp run data get storage api:uuid temp[0].uuid[2]
+execute store result score #storage_uuid_3 temp run data get storage api:uuid temp[0].uuid[3]
+
+function api:uuid/check/compare_uuids
+
+execute if score #matches temp matches 1 store result score #foundId temp run data get storage api:uuid temp[0].id
+
+scoreboard players remove #lenght temp 1
+
+data remove storage api:uuid temp[0]
+
+execute unless score #lenght temp matches ..0 if score #matches temp matches 0 run function api:uuid/check/without_id/repeat

--- a/data/api/functions/uuid/init.mcfunction
+++ b/data/api/functions/uuid/init.mcfunction
@@ -1,0 +1,1 @@
+data merge storage api:uuid {list: []}

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -1,13 +1,4 @@
-execute as @a[team=] run tellraw @s [{"selector":"@s","color":"aqua"},{"text":" joined for the first time!","color":"green"}]
-scoreboard players set @a[team=] rank 90
-scoreboard players set @a[team=] l 1
-team join 90player @a[team=]
-
-scoreboard players set @a[scores={rejoin=1..}] l 1
-execute as @a[scores={rejoin=1..}] run tellraw @s [{"text":"Welcome back, ","color":"green"},{"selector":"@s"},{"text":"!"}]
-scoreboard players reset @a[scores={rejoin=1..}] rejoin
-
-execute at @a[tag=lobby,nbt={SelectedItem:{id:"minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
+execute at @a[tag=lobby,nbt={SelectedItem: {id: "minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
 
 tellraw @a[scores={Party=-2}] [{"text":"[","color":"gray"},{"text":"Party","color":"gold"},{"text":"] "},{"text":"All party commands:\n","color":"yellow"},{"text":"- /trigger Party set -1: Leave the current party\n","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger Party set -1"}},{"text":"- /trigger Party set <ID>: Invite the player with the ID into your party","color":"yellow","clickEvent":{"action":"suggest_command","value":"/trigger Party set "}}]
 scoreboard players set @a Party -3

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -1,5 +1,4 @@
-execute at @a[tag=lobby,nbt={SelectedItem: {id: "minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
-
+execute at @a[tag=lobby,nbt={SelectedItem:{id:"minecraft:compass"}}] unless entity @e[type=chest_minecart,tag=lobby_gui,distance=..5] run function vm:gui/create
 tellraw @a[scores={Party=-2}] [{"text":"[","color":"gray"},{"text":"Party","color":"gold"},{"text":"] "},{"text":"All party commands:\n","color":"yellow"},{"text":"- /trigger Party set -1: Leave the current party\n","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger Party set -1"}},{"text":"- /trigger Party set <ID>: Invite the player with the ID into your party","color":"yellow","clickEvent":{"action":"suggest_command","value":"/trigger Party set "}}]
 scoreboard players set @a Party -3
 scoreboard players enable @a Party

--- a/data/vm/functions/join_server/first.mcfunction
+++ b/data/vm/functions/join_server/first.mcfunction
@@ -1,0 +1,8 @@
+# This function is executed for every player that joins the server for the first time. 
+
+function api:players/create/current
+
+tellraw @s [{"selector":"@s","color":"aqua"},{"text":" joined for the first time!","color":"green"}]
+scoreboard players set @s rank 90
+scoreboard players set @s l 1
+team join 90player @s

--- a/data/vm/functions/join_server/index.mcfunction
+++ b/data/vm/functions/join_server/index.mcfunction
@@ -1,0 +1,3 @@
+# By calling this method the uuid of the player will be checked and one of the functions first, other_name or main will be called
+function api:uuid/check
+scoreboard players reset @s rejoin

--- a/data/vm/functions/join_server/main.mcfunction
+++ b/data/vm/functions/join_server/main.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set @s l 1
+tellraw @s [{"text":"Welcome back, ","color":"green"},{"selector":"@s"},{"text":"!"}]

--- a/data/vm/functions/join_server/other_name.mcfunction
+++ b/data/vm/functions/join_server/other_name.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players operation @s ID = #foundId temp
+
+function vm:join_server/other_name/update_scoreboards

--- a/data/vm/functions/join_server/other_name/update_scoreboards.mcfunction
+++ b/data/vm/functions/join_server/other_name/update_scoreboards.mcfunction
@@ -1,0 +1,17 @@
+function api:players/get/current
+
+execute store result score @s rank run data get storage api:players current.rankId
+
+execute store result score @s playtime run data get storage api:players current.lobby.playtime
+execute store result score @s coins run data get storage api:players current.lobby.coins
+
+execute store result score @s skywarsgames run data get storage api:players current.statistics.skywars.games
+execute store result score @s skywarswins run data get storage api:players current.statistics.skywars.wins
+execute store result score @s skywarsalldeath run data get storage api:players current.statistics.skywars.deaths
+execute store result score @s skywarsallkills run data get storage api:players current.statistics.skywars.kills
+
+execute store result score @s bedwarsgames run data get storage api:players current.statistics.bedwars.games
+execute store result score @s bedwarswins run data get storage api:players current.statistics.bedwars.wins
+execute store result score @s bedwarsallbeds run data get storage api:players current.statistics.bedwars.beds
+execute store result score @s bedwarsalldeath run data get storage api:players current.statistics.bedwars.deaths
+execute store result score @s bedwarsallkills run data get storage api:players current.statistics.bedwars.kills

--- a/data/vm/functions/tick.mcfunction
+++ b/data/vm/functions/tick.mcfunction
@@ -1,20 +1,21 @@
-execute as @a[tag=!registered] run function api:players/create/current
+execute as @a[tag=!registered] run function vm:join_server/first
+execute as @a[scores={rejoin=1..}] run function vm:join_server/index
 
 execute as @a[tag=skywars,nbt={OnGround: 0b}] store result score @s apply_damage run data get entity @s FallDistance
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run scoreboard players remove @s apply_damage 3
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run function vm:damage
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run scoreboard players remove @s apply_damage 3
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run function vm:damage
 
 execute as @a[scores={l=1..}] run function vm:leave
 tp @a[scores={l=1..}] 0 19 0
 execute as @a[scores={l=1..}] run gamemode adventure @s
-item replace entity @a[scores={l=1..}] hotbar.4 with compass{display:{Name:'{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
+item replace entity @a[scores={l=1..}] hotbar.4 with compass{display: {Name: '{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
 tag @a[scores={l=1..}] add lobby
 scoreboard players reset @a[scores={l=1..}] l
 scoreboard players enable @a l
 
-item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage:430,HideFlags:1,Enchantments:[{id:"minecraft:binding_curse",lvl:1s},{id:"minecraft:vanishing_curse",lvl:1s}]}
-effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] levitation 1 11 true
-execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
+item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage: 430, HideFlags: 1, Enchantments: [{id: "minecraft:binding_curse", lvl: 1s}, {id: "minecraft:vanishing_curse", lvl: 1s}]}
+effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] levitation 1 11 true
+execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
 
 execute as @e[type=chest_minecart,tag=lobby_gui] store result score @s temp run data get entity @s Items
 execute as @e[type=chest_minecart,tag=lobby_gui] unless score @s temp = @s value run function vm:gui/click

--- a/data/vm/functions/tick.mcfunction
+++ b/data/vm/functions/tick.mcfunction
@@ -2,20 +2,20 @@ execute as @a[tag=!registered] run function vm:join_server/first
 execute as @a[scores={rejoin=1..}] run function vm:join_server/index
 
 execute as @a[tag=skywars,nbt={OnGround: 0b}] store result score @s apply_damage run data get entity @s FallDistance
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run scoreboard players remove @s apply_damage 3
-execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround: 1b}] run function vm:damage
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run scoreboard players remove @s apply_damage 3
+execute as @a[scores={apply_damage=1..},gamemode=!creative,gamemode=!spectator,nbt={OnGround:1b}] run function vm:damage
 
 execute as @a[scores={l=1..}] run function vm:leave
 tp @a[scores={l=1..}] 0 19 0
 execute as @a[scores={l=1..}] run gamemode adventure @s
-item replace entity @a[scores={l=1..}] hotbar.4 with compass{display: {Name: '{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
+item replace entity @a[scores={l=1..}] hotbar.4 with compass{display:{Name:'{"text":"§6§lMenu","color":"gold","bold":true,"italic":false}'}}
 tag @a[scores={l=1..}] add lobby
 scoreboard players reset @a[scores={l=1..}] l
 scoreboard players enable @a l
 
-item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage: 430, HideFlags: 1, Enchantments: [{id: "minecraft:binding_curse", lvl: 1s}, {id: "minecraft:vanishing_curse", lvl: 1s}]}
-effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] levitation 1 11 true
-execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying: 1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
+item replace entity @a[tag=lobby,gamemode=adventure,scores={doublejump=1..}] armor.chest with elytra{Damage:430,HideFlags:1,Enchantments:[{id:"minecraft:binding_curse",lvl:1s},{id:"minecraft:vanishing_curse",lvl:1s}]}
+effect give @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] levitation 1 11 true
+execute as @a[tag=lobby,gamemode=adventure,nbt={FallFlying:1b}] at @s run playsound minecraft:entity.cat.hiss master @s ~ ~ ~
 
 execute as @e[type=chest_minecart,tag=lobby_gui] store result score @s temp run data get entity @s Items
 execute as @e[type=chest_minecart,tag=lobby_gui] unless score @s temp = @s value run function vm:gui/click


### PR DESCRIPTION
---
name: Add UUID api and improve join logic
about: In this pullrequest the uuid api is added to allow the detection of name changes. Additionally the join logic was improved.
assignees: @Meierschlumpf 

---

The new added uuid api allows to save all uuids of the joined players and matching them with their player id. By that it is possible to find out which ID a player had before he changed his name. 


What needs to be done for full functionallity:
- Run the function `api:uuid/init` to initialize the data storage.
- Run for each player that has already been registered the function `api:uuid/add`.