### PR TITLE
Add game mode switcher via /trigger gm

### DIFF
--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -15,6 +15,14 @@ execute as @a[scores={joinme=-1},tag=joinme,tag=!lobby] run function vm:joinme
 scoreboard players set @a joinme -2
 scoreboard players enable @a joinme
 
+tellraw @a[scores={gm=0}] [{"text":"","color":"yellow"},{"text":"[","color":"gray"},{"text":"Game Mode","color":"gold"},{"text":"] ","color":"gray"},{"text":"How to switch game modes:\n","color":"aqua"},{"text":"- /trigger gm: Show this message\n"},{"text":"- /trigger gm set 1: Switch to creative mode\n"},{"text":"- /trigger gm set 2: Switch to adventure mode\n"},{"text":"- /trigger gm set 3: Switch to spectator mode"}]
+execute as @a[scores={gm=1}] run gamemode creative
+execute as @a[scores={gm=2}] run gamemode adventure
+execute as @a[scores={gm=3}] run gamemode spectator
+scoreboard players set @a[scores={gm=0..}] gm -1
+scoreboard players enable @a[scores={rank=..20}] gm
+scoreboard players enable @a[tag=gm] gm
+
 execute as @a[gamemode=!adventure,gamemode=!spectator,tag=!gm,tag=!skywars,tag=!bedwars,tag=!bingo] run gamemode adventure @s
 execute as @a[tag=nohitcooldown] run attribute @s minecraft:generic.attack_speed base set 100
 execute as @a[tag=!nohitcooldown] run attribute @s minecraft:generic.attack_speed base set 4

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -15,10 +15,10 @@ execute as @a[scores={joinme=-1},tag=joinme,tag=!lobby] run function vm:joinme
 scoreboard players set @a joinme -2
 scoreboard players enable @a joinme
 
-tellraw @a[scores={gm=0}] [{"text":"","color":"yellow"},{"text":"[","color":"gray"},{"text":"Game Mode","color":"gold"},{"text":"] ","color":"gray"},{"text":"How to switch game modes:\n","color":"aqua"},{"text":"- /trigger gm: Show this message\n"},{"text":"- /trigger gm set 1: Switch to creative mode\n"},{"text":"- /trigger gm set 2: Switch to adventure mode\n"},{"text":"- /trigger gm set 3: Switch to spectator mode"}]
-execute as @a[scores={gm=1}] run gamemode creative
-execute as @a[scores={gm=2}] run gamemode adventure
-execute as @a[scores={gm=3}] run gamemode spectator
+tellraw @a[scores={gm=0},tag=gm] [{"text":"","color":"yellow"},{"text":"[","color":"gray"},{"text":"Game Mode","color":"gold"},{"text":"] ","color":"gray"},{"text":"How to switch game modes:\n","color":"aqua"},{"text":"- /trigger gm: Show this message\n"},{"text":"- /trigger gm set 1: Switch to creative mode\n"},{"text":"- /trigger gm set 2: Switch to adventure mode\n"},{"text":"- /trigger gm set 3: Switch to spectator mode"}]
+execute as @a[scores={gm=1},tag=gm] run gamemode creative
+execute as @a[scores={gm=2},tag=gm] run gamemode adventure
+execute as @a[scores={gm=3},tag=gm] run gamemode spectator
 scoreboard players set @a[scores={gm=0..}] gm -1
 scoreboard players enable @a[tag=gm] gm
 

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -16,9 +16,9 @@ scoreboard players set @a joinme -2
 scoreboard players enable @a joinme
 
 tellraw @a[scores={gm=0},tag=gm] [{"text":"","color":"yellow"},{"text":"[","color":"gray"},{"text":"Game Mode","color":"gold"},{"text":"] ","color":"gray"},{"text":"How to switch game modes:\n","color":"aqua"},{"text":"- /trigger gm: Show this message\n"},{"text":"- /trigger gm set 1: Switch to creative mode\n"},{"text":"- /trigger gm set 2: Switch to adventure mode\n"},{"text":"- /trigger gm set 3: Switch to spectator mode"}]
-execute as @a[scores={gm=1},tag=gm] run gamemode creative
-execute as @a[scores={gm=2},tag=gm] run gamemode adventure
-execute as @a[scores={gm=3},tag=gm] run gamemode spectator
+execute as @a[scores={gm=1},tag=gm] run gamemode creative @s
+execute as @a[scores={gm=2},tag=gm] run gamemode adventure @s
+execute as @a[scores={gm=3},tag=gm] run gamemode spectator @s
 scoreboard players set @a[scores={gm=0..}] gm -1
 scoreboard players enable @a[tag=gm] gm
 

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -20,7 +20,6 @@ execute as @a[scores={gm=1}] run gamemode creative
 execute as @a[scores={gm=2}] run gamemode adventure
 execute as @a[scores={gm=3}] run gamemode spectator
 scoreboard players set @a[scores={gm=0..}] gm -1
-scoreboard players enable @a[scores={rank=..20}] gm
 scoreboard players enable @a[tag=gm] gm
 
 execute as @a[gamemode=!adventure,gamemode=!spectator,tag=!gm,tag=!skywars,tag=!bedwars,tag=!bingo] run gamemode adventure @s

--- a/data/vm/functions/info.mcfunction
+++ b/data/vm/functions/info.mcfunction
@@ -10,6 +10,7 @@ scoreboard objectives add l trigger {"text":"Hub","color":"gold"}
 scoreboard objectives add Help trigger {"text":"Help","color":"gold"}
 scoreboard objectives add Party trigger {"text":"Party","color":"gold"}
 scoreboard objectives add joinme trigger {"text":"JoinMe","color":"gold"}
+scoreboard objectives add gm trigger {"text":"Game Mode","color":"gold"}
 scoreboard objectives add partyID dummy
 scoreboard objectives add playtime minecraft.custom:minecraft.play_time
 scoreboard objectives add apply_damage dummy


### PR DESCRIPTION
Add the game mode switcher, accessible through `/trigger gm` with the `gm` tag.
Usage is shown below.
![image](https://user-images.githubusercontent.com/75318636/231278686-88c17a04-f21c-4c11-ac2a-4adbd2b01e9a.png)
