### PR TITLE
Give players the ability to spectate others via /trigger Spec

### DIFF
--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -22,6 +22,10 @@ execute as @a[scores={gm=3},tag=gm] run gamemode spectator @s
 scoreboard players set @a[scores={gm=0..}] gm -1
 scoreboard players enable @a[tag=gm] gm
 
+execute as @a[scores={Spec=0..}] run gamemode spectator @s
+scoreboard players set @a Spec -1
+scoreboard players enable @a Spec
+
 execute as @a[gamemode=!adventure,gamemode=!spectator,tag=!gm,tag=!skywars,tag=!bedwars,tag=!bingo] run gamemode adventure @s
 execute as @a[tag=nohitcooldown] run attribute @s minecraft:generic.attack_speed base set 100
 execute as @a[tag=!nohitcooldown] run attribute @s minecraft:generic.attack_speed base set 4

--- a/data/vm/functions/5t.mcfunction
+++ b/data/vm/functions/5t.mcfunction
@@ -23,6 +23,7 @@ scoreboard players set @a[scores={gm=0..}] gm -1
 scoreboard players enable @a[tag=gm] gm
 
 execute as @a[scores={Spec=0..}] run gamemode spectator @s
+execute as @a if score @s ID = @r[scores={Spec=1..}] Spec run spectate @s @r[scores={Spec=1..}]
 scoreboard players set @a Spec -1
 scoreboard players enable @a Spec
 

--- a/data/vm/functions/info.mcfunction
+++ b/data/vm/functions/info.mcfunction
@@ -11,6 +11,7 @@ scoreboard objectives add Help trigger {"text":"Help","color":"gold"}
 scoreboard objectives add Party trigger {"text":"Party","color":"gold"}
 scoreboard objectives add joinme trigger {"text":"JoinMe","color":"gold"}
 scoreboard objectives add gm trigger {"text":"Game Mode","color":"gold"}
+scoreboard objectives add Spec trigger {"text":"Spectator","color":"gold"}
 scoreboard objectives add partyID dummy
 scoreboard objectives add playtime minecraft.custom:minecraft.play_time
 scoreboard objectives add apply_damage dummy


### PR DESCRIPTION
Add the ability to switch to spectator mode and spectate players, accessible through `/trigger Spec`.
To switch to spectator mode, you just run `/trigger Spec`.
To spectate a player, you look at the tab list to find their ID and then run `/trigger Spec set <ID>`.